### PR TITLE
ci: configure simple github action deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+name: Build and Deploy
+on:
+  push:
+    branches:
+      - master
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          cache: yarn
+      - name: Yarn Install
+        run: yarn install --frozen-lockfile
+      - name: Build
+        run: yarn build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-academie-des-renards.dunstetter.fr

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "start": "rm -rf .parcel-cache && parcel serve ./index.html",
     "start-css": "sass --watch styles/style.scss styles/style.css",
     "build-css": "sass styles/style.scss styles/style.css",
-    "build": "rm -rf dist && rm -rf .parcel-cache && yarn build-css && parcel build ./index.html"
+    "prebuild": "rm -rf dist .parcel-cache",
+    "build": "yarn build-css && parcel build ./index.html",
+    "postbuild": "echo 'academie-des-renards.dunstetter.fr' > dist/CNAME"
   },
   "browserslist": [
     "defaults"


### PR DESCRIPTION
## ci: configure simple github action deploy workflow (#23)

Setup a Github Action workflow to deploy the builded project onto the branch `gh-pages` thanks to https://github.com/peaceiris/actions-gh-pages

Replace the static CNAME file with a `postbuild` script in order to create the file in the dist folder after build.

Move clean step at the `build` script into the `prebuild` script.