### PR TITLE
Adjust the deployment workflow to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
   pull_request: {}
 
 concurrency:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,8 @@ name: Build and Deploy
 on:
   push:
     branches:
-      - master
+      - main
+on: workflow_dispatch
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- The default branch is now called `main`
- Add the possibility to dispatch the deployment workflow manually