### PR TITLE
Fix deployment workflow syntax

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
 name: Build and Deploy
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
-on: workflow_dispatch
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
There should be [one `on`](https://docs.github.com/fr/enterprise-cloud@latest/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#using-activity-types-and-filters-with-multiple-events); it's okay not to have a config after `:`.